### PR TITLE
Added Stylelint Script

### DIFF
--- a/.stylelintrc.json
+++ b/.stylelintrc.json
@@ -1,3 +1,3 @@
 {
-  "extends": "stylelint-config-standard"
+  "extends": ["stylelint-config-standard", "stylelint-config-prettier"]
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -4842,6 +4842,12 @@
         }
       }
     },
+    "stylelint-config-prettier": {
+      "version": "8.0.2",
+      "resolved": "https://registry.npmjs.org/stylelint-config-prettier/-/stylelint-config-prettier-8.0.2.tgz",
+      "integrity": "sha512-TN1l93iVTXpF9NJstlvP7nOu9zY2k+mN0NSFQ/VEGz15ZIP9ohdDZTtCWHs5LjctAhSAzaILULGbgiM0ItId3A==",
+      "dev": true
+    },
     "stylelint-config-recommended": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/stylelint-config-recommended/-/stylelint-config-recommended-4.0.0.tgz",

--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
     "build": "next build",
     "start": "next start",
     "eslint": "eslint.",
+    "slint": "stylelint '**/*.css' ",
     "prettify": "prettier --write ."
   },
   "dependencies": {
@@ -25,6 +26,7 @@
     "eslint-plugin-react": "^7.22.0",
     "prettier": "2.2.1",
     "stylelint": "^13.12.0",
+    "stylelint-config-prettier": "^8.0.2",
     "stylelint-config-standard": "^21.0.0"
   }
 }


### PR DESCRIPTION
StyleLint
https://stylelint.io/user-guide/get-started
npm install --save-dev stylelint stylelint-config-standard
echo '{\n"extends": "stylelint-config-standard"\n}' > .stylelintrc.json
check the installation with: npx stylelint "**/*.css"
Add a style script "slint": "stylelint '**/*.css' ",
StyleLint with Prettier
https://github.com/prettier/stylelint-config-prettier
npm install --save-dev stylelint-config-prettier
Then, append stylelint-config-prettier to the extends array in your .stylelintrc.\* file. Make sure to put it last, so it will override other configs. { "extends": [ "stylelint-config-standard", "stylelint-config-prettier" ] }
